### PR TITLE
Fix file upload for API v2

### DIFF
--- a/DropboxClient.php
+++ b/DropboxClient.php
@@ -348,7 +348,7 @@ class DropboxClient
             return $this->apiCall('2/files/upload_session/finish', array(
                 'cursor' => compact('session_id', 'offset'),
                 'commit' => $commit_params
-            ));
+            ), true);
         } else {
             return $this->apiCall("2/files/upload", $commit_params, true, file_get_contents($src_file));
         }


### PR DESCRIPTION
API call "2/files/upload_session/finish" needs to go to content.dropboxapi.com, not api.dropboxapi.com