### PR TITLE
Fixed PHP errors in compatMeta() when $meta->size was not set

### DIFF
--- a/DropboxClient.php
+++ b/DropboxClient.php
@@ -283,9 +283,9 @@ class DropboxClient
 
     static function compatMeta($meta)
     {
-        $meta->is_dir = !isset($meta->size) || is_null($meta->size);
+        $meta->is_dir = $meta->{'.tag'} == "folder";
         $meta->path = $meta->path_display;
-        $meta->bytes = $meta->size;
+        $meta->bytes = isset($meta->size) ? $meta->size : 0;
         return $meta;
     }
 


### PR DESCRIPTION
I had the problem that PHP (7) raised an error in `compatMeta()` because `$meta->size` was not set.